### PR TITLE
Fixes to make the circuit in README work

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,14 @@ Generate, visualize and analyze electrical networks.
 
 ## Creating a circuit
 
-The simplest way to create a circuit is through the `@circuit` macro.  An
+The simplest way to create a circuit is through the `@circuit` macro.  As an
 example, here a square network is generated with two named (`a` and  `b`) and
 two unnamed (or rather not explicitly named) nodes, one voltage source, a
 resistor and a capacitor in series and a capacitor and an inductor in parallel:
 
 ```julia
 c = @circuit begin
-    b:(0,0) --> VoltageSource(3) --> (1,0) --> Resistor(4) --> Inductor(2) --> (1,1) --> a:(0,1)
+    b:(0,0) --> VSource(3) --> (1,0) --> Resistor(4) --> Inductor(2) --> (1,1) --> a:(0,1)
     :a --> Capacitor(1) // Inductor(4) --> :b
 end
 ```
@@ -59,7 +59,7 @@ Series(Resistor(4),Inductor(2),Parallel(Capacitor(1),Inductor(4)))`),
 resistor experiences a voltage drop of ``V₀``, and the rest of the components
 none (as expected for DC voltage). `voltageDivision(n,1im) ==  [0.97 - 0.16im,
 0.081 + 0.48im, [-0.054 - 0.32im, -0.054 - 0.32im]]` (so at ``1`` frequency
-unit, those are the respective responses in each component)
+unit, those are the respective responses in each component).
 
 Current division works the same: `currentDivision(n) == [1, 1, [0.0, NaN]]`
 (the NaN is from an `Inf/Inf`, a good symbolic package will probably fix this,

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -14,14 +14,14 @@ Generate, visualize and analyze electrical networks.
 
 ## Creating a circuit
 
-The simplest way to create a circuit is through the `@circuit` macro.  An
+The simplest way to create a circuit is through the `@circuit` macro.  As an
 example, here a square network is generated with two named (`a` and  `b`) and
 two unnamed (or rather not explicitly named) nodes, one voltage source, a
 resistor and a capacitor in series and a capacitor and an inductor in parallel:
 
 ```julia
 c = @circuit begin
-    b:(0,0) --> VoltageSource(3) --> (1,0) --> Resistor(4) --> Inductor(2) --> (1,1) --> a:(0,1)
+    b:(0,0) --> VSource(3) --> (1,0) --> Resistor(4) --> Inductor(2) --> (1,1) --> a:(0,1)
     :a --> Capacitor(1) // Inductor(4) --> :b
 end
 ```
@@ -68,7 +68,7 @@ Series(Resistor(4),Inductor(2),Parallel(Capacitor(1),Inductor(4)))`),
 resistor experiences a voltage drop of ``V₀``, and the rest of the components
 none (as expected for DC voltage). `voltageDivision(n,1im) ==  [0.97 - 0.16im,
 0.081 + 0.48im, [-0.054 - 0.32im, -0.054 - 0.32im]]` (so at ``1`` frequency
-unit, those are the respective responses in each component)
+unit, those are the respective responses in each component).
 
 Current division works the same: `currentDivision(n) == [1, 1, [0.0, NaN]]`
 (the NaN is from an `Inf/Inf`, a good symbolic package will probably fix this,

--- a/src/Circuits.jl
+++ b/src/Circuits.jl
@@ -143,8 +143,8 @@ function push_stuff!(e::Expr, coord, comp)
     if head === :call
         if args[1] === ://
             # component // component
-            left = push_stuff!(args[1], coord, comp)
-            right = push_stuff!(args[2], coord, comp)
+            left = push_stuff!(args[2], coord, comp)
+            right = push_stuff!(args[3], coord, comp)
             return :(Parallel($left, $right))
         end
         if args[1] === :(:)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,6 +12,13 @@ using Test
     lcr = Series(l, c, r)
 
     @test Circuits.impedance(lcr, 5u"kHz") ≈ 110.0u"Ω"
+
+    c = @circuit begin
+        b:(0, 0) -->
+        VSource(3) --> (1, 0) --> Resistor(4) --> Inductor(2) --> (1, 1) --> a:(0, 1)
+        :a --> Capacitor(1)//Inductor(4) --> :b
+    end
+    @test c.coordinates == Dict(:a => (0, 1), :b => (0, 0), 2 => (1, 1), 1 => (1, 0))
 end
 
 @testset "Formatting" begin


### PR DESCRIPTION
The circuit in the README doesn't work as it currently stands because:

* `VoltageSource` is unexported and an abstract type, the circuit should use `VSource` instead
* The code handling `//` in the circuit expression was incorrectly trying to push `//` itself as a component (`args[1]` instead of `args[2]`), and so using `//` in  a circuit definition failed

This PR fixes both of those issues, and further adds a test to `runtests.jl` to make sure that the basic example shown in the README remains tested and in working condition. 