### PR TITLE
Fix version compat info: 1.6 and above only

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: '1.5'
+          version: '1.8'
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@ language: julia
 notifications:
   email: false
 julia:
-  - 1.0
-  - 1.5
+  - 1.6
   - nightly
 os:
   - linux

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
 
 [compat]
 Latexify = "0.14, 0.15"
-julia = "1"
+julia = "1.6"
 
 [extras]
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Circuits"
 uuid = "d2a218f5-c9f8-4bfd-b3ab-fe354e20ba05"
 authors = ["David Gustavsson <david.e.gustavsson@gmail.com> and contributors"]
-version = "0.1.0"
+version = "0.1.1"
 
 [deps]
 Latexify = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"


### PR DESCRIPTION
Hi!

Since you mentioned the docs not building as a known issue in the last PR, I looked into it. 
Defining `-->` as a function is available [only from Julia 1.6 onwards](https://github.com/JuliaLang/julia/blob/release-1.6/NEWS.md#language-changes), but the docs.yml file specifies Julia 1.5 as the one to use to build them. That was the reason for the failures. 

In fact, the project doesn't even load before this support was added (in Julia 1.6), so this project isn't compatible with Julia 1.5 and earlier (`using Circuits` fails with an error message). 

So this PR changes the minimum version compatibility spec in Project.toml to be Julia 1.6, and also fixes the issue of docs not building.